### PR TITLE
refactor: Use environment variable for database URL

### DIFF
--- a/utils/streamlit_postgres_functions.py
+++ b/utils/streamlit_postgres_functions.py
@@ -12,9 +12,16 @@ from sqlalchemy.exc import SQLAlchemyError
 from datetime import date, datetime
 from typing import Tuple, List, Dict
 import re, unicodedata
+import os
 
 
-db_url = "postgresql://postgres:LlMQsPXTOlvnvtSwGJyitvqCOyhIOXzc@trolley.proxy.rlwy.net:43349/railway?sslmode=require"
+# --- Database Connection ---
+# For Railway deployment, the DATABASE_URL is injected as an environment variable.
+# The hardcoded URL is a fallback for local development only.
+db_url = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://postgres:LlMQsPXTOlvnvtSwGJyitvqCOyhIOXzc@trolley.proxy.rlwy.net:43349/railway?sslmode=require"
+)
 
 
 # Cache the engine once per session


### PR DESCRIPTION
Prepare the application for deployment on Railway by updating the database connection logic.

- Modified `utils/streamlit_postgres_functions.py` to read the database connection string from the `DATABASE_URL` environment variable.
- This is the standard practice for PaaS platforms like Railway, which injects the database URL as an environment variable.
- The hardcoded database URL is retained as a fallback to support local development environments where the `DATABASE_URL` might not be set.