### PR TITLE
feat: Add comprehensive error logging

### DIFF
--- a/pages/1_GERMANY_PSP_postgres.py
+++ b/pages/1_GERMANY_PSP_postgres.py
@@ -14,6 +14,7 @@ import pandas as pd
 from st_aggrid import AgGrid, GridOptionsBuilder
 from datetime import datetime
 from datetime import date, timedelta
+import logging
 import utils.streamlit_postgres_functions as spf
 from utils.data_bootstrap import ensure_bootstrap, get_dataframes
 
@@ -808,7 +809,9 @@ elif chosen_tab == "Edit Existing Order":
                 st.session_state["flash_toast"] = f"✅ Order {order_id} updated."
                 st.rerun()
             else:
-                st.error(f'Update failed: {result.get("error")}')
+                error_message = result.get("error")
+                logging.error(f"Failed to update LPO order {order_id}: {error_message}")
+                st.error(f'Update failed: {error_message}')
 
     elif dataset_choice == "Samples":
         # --- normalize selected_row to a dict ---
@@ -970,7 +973,9 @@ elif chosen_tab == "Edit Existing Order":
                 st.session_state["flash_toast"] = f"✅ Sample {sample_id} updated."
                 st.rerun()
             else:
-                st.error(f'Update failed: {result.get("error")}')
+                error_message = result.get("error")
+                logging.error(f"Failed to update Sample order {sample_id}: {error_message}")
+                st.error(f'Update failed: {error_message}')
         
 #### TAB 3B
 elif chosen_tab == "Add New Order":
@@ -1096,8 +1101,11 @@ elif chosen_tab == "Add New Order":
                 st.session_state["flash_toast"] = f'✅ Order added to LPO! (Order_id={result.get("inserted_pk")})'
                 st.rerun()
             else:
-                st.error(f'Insert failed: {result.get("error")}')
-                for col, msg in (result.get("errors") or {}).items():
+                error_message = result.get("error")
+                validation_errors = result.get("errors")
+                logging.error(f"Failed to insert LPO order. Error: {error_message}. Validation errors: {validation_errors}")
+                st.error(f'Insert failed: {error_message}')
+                for col, msg in (validation_errors or {}).items():
                     st.warning(f"{col}: {msg}")
 
 
@@ -1176,6 +1184,7 @@ elif chosen_tab == "Add New Order":
             try:
                 result = spf.insert_order_row("Samples_PSPGermany", new_row)
             except Exception as e:
+                logging.exception("An unhandled exception occurred while inserting a Sample order.")
                 st.exception(e)  # shows full traceback
             
             if result.get("ok"):
@@ -1184,8 +1193,11 @@ elif chosen_tab == "Add New Order":
                 st.session_state["flash_toast"] = f'✅ Order added to Sample Orders! (Sample_id={result.get("inserted_pk")})'
                 st.rerun()
             else:
-                st.error(f'Insert failed: {result.get("error")}')
-                for col, msg in (result.get("errors") or {}).items():
+                error_message = result.get("error")
+                validation_errors = result.get("errors")
+                logging.error(f"Failed to insert Sample order. Error: {error_message}. Validation errors: {validation_errors}")
+                st.error(f'Insert failed: {error_message}')
+                for col, msg in (validation_errors or {}).items():
                     st.warning(f"{col}: {msg}")
 
 

--- a/utils/streamlit_postgres_functions.py
+++ b/utils/streamlit_postgres_functions.py
@@ -13,6 +13,7 @@ from datetime import date, datetime
 from typing import Tuple, List, Dict
 import re, unicodedata
 import os
+import logging
 
 
 # --- Database Connection ---
@@ -214,6 +215,7 @@ def insert_order_row(table_name: str, row: dict) -> dict:
             pk = res.scalar()
         return {"ok": True, "inserted_pk": pk, "clean": clean, "errors": {}}
     except Exception as e:
+        logging.error(f"Database insert failed for table {table_name}", exc_info=True)
         return {"ok": False, "error": str(e), "clean": clean, "errors": {}}
 
 def update_order_row(table_name: str, order_id: int, row: dict) -> dict:
@@ -263,4 +265,5 @@ def update_order_row(table_name: str, order_id: int, row: dict) -> dict:
             "errors": {},
         }
     except Exception as e:
+        logging.error(f"Database update failed for table {table_name}, pk {order_id}", exc_info=True)
         return {"ok": False, "error": str(e), "clean": clean, "errors": {}}


### PR DESCRIPTION
Add logging to all error handling locations to ensure that technical details of errors are captured in the server logs.

- Imported the `logging` module in `pages/1_GERMANY_PSP_postgres.py` and `utils/streamlit_postgres_functions.py`.
- Added `logging.error()` and `logging.exception()` calls alongside the existing `st.error()` and `st.exception()` calls in the UI layer. This ensures that when a user sees an error, a detailed log is also generated for debugging.
- Added `logging.error(..., exc_info=True)` in the database utility functions to log the full exception traceback when database operations fail.