### PR TITLE
Handle sample order insertion errors gracefully

### DIFF
--- a/pages/1_GERMANY_PSP_postgres.py
+++ b/pages/1_GERMANY_PSP_postgres.py
@@ -1180,10 +1180,11 @@ elif chosen_tab == "Add New Order":
                 "Remarks": remarks,
             }
             new_row = {k: v for k, v in new_row.items() if v is not None}
-            print(new_row)
+            result = {"ok": False}
             try:
                 result = spf.insert_order_row("Samples_PSPGermany", new_row)
             except Exception as e:
+                result["error"] = str(e)
                 logging.exception("An unhandled exception occurred while inserting a Sample order.")
                 st.exception(e)  # shows full traceback
             


### PR DESCRIPTION
## Summary
- Initialize sample order `result` structure before calling the DB insert
- Remove stray debug print and ensure exceptions populate `result['error']`

## Testing
- `python -m py_compile pages/1_GERMANY_PSP_postgres.py`


------
https://chatgpt.com/codex/tasks/task_e_68c074f57c4c8331b30037b0199d4a33